### PR TITLE
[fix] Fix SlsVersionMatcher comparison

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },
@@ -13,4 +13,4 @@
             "tsConfigFile": "src/tsconfig.json"
         }
     }
-}
+};

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "compile": "tsc -p src",
     "lint": "tslint 'src/**/*.ts*' --format codeFrame --project ./src/tsconfig.json",
     "lint-fix": "yarn lint -- --fix --project ./src/tsconfig.json",
-    "test": "jest --config jest.config.json",
+    "test": "jest --config jest.config.js",
     "circle-publish": "./scripts/circle-publish-npm"
   },
   "devDependencies": {

--- a/src/slsVersionMatcher.ts
+++ b/src/slsVersionMatcher.ts
@@ -97,7 +97,7 @@ export class SlsVersionMatcher implements ISlsVersionMatcher {
     ) {}
 
     public matches(version: ISlsVersion) {
-        if (version.rc !== undefined) {
+        if (version.rc != null || version.snapshot != null) {
             return false;
         }
 
@@ -111,21 +111,21 @@ export class SlsVersionMatcher implements ISlsVersionMatcher {
         }
 
         if (this.major !== undefined) {
-            const comparison = compareNumbers(version.major, this.major);
+            const comparison = compareNumbers(this.major, version.major);
             if (comparison !== 0) {
                 return comparison;
             }
         }
 
         if (this.minor !== undefined) {
-            const comparison = compareNumbers(version.minor, this.minor);
+            const comparison = compareNumbers(this.minor, version.minor);
             if (comparison !== 0) {
                 return comparison;
             }
         }
 
         if (this.patch !== undefined) {
-            const comparison = compareNumbers(version.patch, this.patch);
+            const comparison = compareNumbers(this.patch, version.patch);
             if (comparison !== 0) {
                 return comparison;
             }


### PR DESCRIPTION
Fixes issue where the comparison result was reversed for `SlsVersionMatcher` with wild card (`"x"`) versions